### PR TITLE
Cleaning up presentation of the guide.

### DIFF
--- a/src/main/resources/assets/matteroverdrive/info/en_us/tile.replicator.xml
+++ b/src/main/resources/assets/matteroverdrive/info/en_us/tile.replicator.xml
@@ -19,27 +19,27 @@
 <entry stylesheet="matteroverdrive:info/styles/guide.css">
     <page class="padded-page">
         <title size="2" class="matter-text small-title">The Replicator</title>
-        <text class="matter-text text-block">$itemName, is a machine, that uses transporter technology to materialize item patterns into their physical counterpart. It works by rearranging subatomic particles on a larger scale, by using [guide name=matter_plasma]. In short, it replicates items and blocks, thus its name, $itemName.</text>
+        <text class="matter-text text-block">$itemName, is a machine, that uses transporter technology to materialize item patterns into their physical counterpart. By rearranging subatomic particles on a larger scale with [guide name=matter_plasma], it replicates items and blocks. Thus its name, $itemName.</text>
         <image width="256" height="90" src="guide/replicator.png"></image>
     </page>
     <page style="margin-left:8px;margin-right:8px;margin-top:6px">
         <title size="2" class="matter-text small-title">How To Use</title>
-        <text class="matter-text text-block">Before you can replicate an item, you must have it's pattern. It can be obtained by using a [item name=matter_scanner] or a [item name=matter_analyzer]. Unfortunately the scanning process destroys the item.
-            Every time the item is scanned, it's progress will increase. A Redstone signal, may required to start the replication process, depending on the redstone setting of the machine.
+        <text class="matter-text text-block">Before you can replicate an item, you must have it's pattern. A pattern can be obtained by scanning the item with a [item name=matter_scanner] or [item name=matter_analyzer]. Unfortunately the scanning process destroys the item.
+            Every time an item is scanned, it's progress to 100% pattern completion will increase. A Redstone signal may be required to start the replication process, depending on the redstone setting of the machine.
             [guide name=matter_plasma] is also required to replicate items. How much depends on the item itself.</text>
         <text class="matter-text">Be warned! The replication process produces high amounts of radiation. Without protective plating any living creature will receive large doses of radiation followed by a ton of negative potion effects, such as Hunger, Nausea, Fatigue,Weakness and Poison. To protect against radiation, a maximum of 5 [item name=tritanium_plate] can be used to protect the user from the deadly radiation. Each plate also decreases the area of effect.</text>
     </page>
     <page style="margin-left:8px;margin-right:8px;margin-top:6px">
         <title size="2" class="matter-text small-title">How To Use</title>
-        <text class="matter-text text-block">If you use an pattern that is processed less than 100%.
-            The replicator will have a greater change to failure and will produce [item name=matter_dust guide=matter_fail].
+        <text class="matter-text text-block">If you use a pattern that is less than 100% complete,
+            the replicator will have a greater chance of failure and will produce [item name=matter_dust guide=matter_fail].
             If you try and replicate an item with a pattern processed at 10% it will fail about 10% of the time.
-            Then you will have to use a [block name=recycler] to convert it into [item name=matter_dust_refined guide=matter_fail] and decompose it back into [guide name=matter_plasma].</text>
+            Then you will have to use a [block name=matter_recycler] to convert it into [item name=matter_dust_refined guide=matter_fail] and decompose it back into [guide name=matter_plasma].</text>
     </page>
     <page class="padded-page">
         <title size="2" class="matter-text small-title ">Matter Network</title>
-        <text class="matter-text text-block">The $itemName can only be connected to its back side. Once connected to a network, the [item name=pattern_monitor] can be used to issue replication tasks, to all replicators connected.
-            The $itemName once given a replication task, will search the Local Network for valid patterns.
+        <text class="matter-text text-block">The $itemName can only have MatterNetworkCables connected to its back side. Once connected to a network, the [item name=pattern_monitor] can be used to issue replication tasks, to all connected replicators.
+            Once given a replication task, the $itemName will search the Local Network for valid patterns.
             A [item name=network_flash_drive] can be used to filter machines with which the $itemName can communicate.</text>
         <image width="64" height="64" src="guide/replicator_connection.png" style="float:left;margin-right:8px"></image>
         <image width="64" height="64" src="guide/replicator_network_filter.png" style="float:left"></image>


### PR DESCRIPTION
-Fixed some issues, such as using "an" when it should be "a", and then some more obvious spelling problems further into the file.
  - I tried to improve the flow of some sentences.
  - Missing the word "be" when it starts talking about redstone.

- [block name=recycler] wasn't working and left a blank space on the in-game guide. idk what i'm doing but it might be because in the xml it's called a matter_recycler, not a recycler. I suspect it couldn't find the original block name in the original attempt. Someone might have renamed the recycler to matter recycler and broke all the references to it.
- [item name=tritanium_plate] doesn't do anything when clicked-on in-game. doesn't have an xml file i guess? should we add one?